### PR TITLE
Cookie Auth in combination with Windows Auth

### DIFF
--- a/src/WebApp/App.razor
+++ b/src/WebApp/App.razor
@@ -1,11 +1,16 @@
-﻿
-<CascadingAuthenticationState>
+﻿<CascadingAuthenticationState>
     <Router AppAssembly="@typeof(Program).Assembly">
         <Found Context="routeData">
-                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <Loading />
+                    <RedirectToLogin />
+                </NotAuthorized>
+            </AuthorizeRouteView>
         </Found>
         <NotFound>
             <LayoutView Layout="@typeof(MainLayout)">
+                <p>Désolé, il n'y a rien à cette adresse.</p>
                 <p>Sorry, there's nothing at this address.</p>
             </LayoutView>
         </NotFound>

--- a/src/WebApp/Area/Identity/Components/LoginDisplay.razor
+++ b/src/WebApp/Area/Identity/Components/LoginDisplay.razor
@@ -1,19 +1,19 @@
-﻿@inject HttpClient Http
+﻿@attribute [Authorize]
+
+@inject HttpClient Http
 @inject IStringLocalizer<App> Localizer
 
 @inject OfficeEntry.Application.Common.Interfaces.ICurrentUserService currentUserService
 @inject OfficeEntry.Application.Common.Interfaces.IDomainUserService _domainUserService
 
-<AuthorizeView>
-    @if (name is null)
-    {
-        <Loading />
-    }
-    else
-    {
-        <div>@Localizer["Hello,"] @name</div>
-    }
-</AuthorizeView>
+@if (name is null)
+{
+    <Loading />
+}
+else
+{
+    <div>@Localizer["Hello,"] @name</div>
+}
 
 @code{
     private string name;
@@ -27,5 +27,5 @@
         }
 
         await base.OnAfterRenderAsync(firstRender);
-    }
+}
 }

--- a/src/WebApp/Area/Identity/Components/RedirectToLogin.razor
+++ b/src/WebApp/Area/Identity/Components/RedirectToLogin.razor
@@ -1,0 +1,9 @@
+﻿@inject NavigationManager Navigation
+@code {
+    protected override void OnAfterRender(bool firstRender)
+    {
+        var returnUrl = Navigation.Uri[Navigation.BaseUri.Length..];
+
+        Navigation.NavigateTo($"external/login?returnUrl=/{returnUrl}", forceLoad: true);
+    }
+}

--- a/src/WebApp/Area/Identity/Controllers/AccountController.cs
+++ b/src/WebApp/Area/Identity/Controllers/AccountController.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace OfficeEntry.WebApp.Area.Identity.Controllers
+{
+    [Route("{controller}/{action}")]
+    public class AccountController : Controller
+    {
+        public IActionResult Login(string returnUrl = "/")
+        {
+            return RedirectToAction("Login", "External", new { returnUrl });
+        }
+    }
+}

--- a/src/WebApp/Area/Identity/Controllers/ExternalController.cs
+++ b/src/WebApp/Area/Identity/Controllers/ExternalController.cs
@@ -1,0 +1,125 @@
+﻿using IdentityModel;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.Negotiate;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading.Tasks;
+
+namespace OfficeEntry.WebApp.Area.Identity.Controllers
+{
+    [Route("{controller}/{action}")]
+    public class ExternalController : Controller
+    {
+        private readonly ILogger<ExternalController> _logger;
+
+        public ExternalController(ILogger<ExternalController> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Entry point into the login workflow
+        /// </summary>
+        [HttpGet]
+        public IActionResult Login(string returnUrl = "/")
+        {
+            // we only have one option for logging in and it's an external provider
+            return RedirectToAction("Challenge", "External", new { provider = NegotiateDefaults.AuthenticationScheme, returnUrl });
+        }
+
+        /// <summary>
+        /// Initiate roundtrip to external authentication provider
+        /// </summary>
+        [HttpGet]
+        public async Task<IActionResult> Challenge(string provider, string returnUrl)
+        {
+            if (string.IsNullOrEmpty(returnUrl)) returnUrl = "~/";
+
+            // validate returnUrl - either it is a valid OIDC URL or back to a local page
+            if (Url.IsLocalUrl(returnUrl) == false)
+            {
+                // user might have clicked on a malicious link - should be logged
+                throw new Exception("invalid return URL");
+            }
+
+            if (NegotiateDefaults.AuthenticationScheme == provider)
+            {
+                return await ProcessNegociateLoginAsync(returnUrl);
+            }
+
+            throw new Exception("Invalid authentication provider.");
+        }
+
+        /// <summary>
+        /// Post processing of external authentication
+        /// </summary>
+        [HttpGet]
+        [Authorize]
+        public async Task<IActionResult> Callback()
+        {
+            // read external identity from the temporary cookie
+            var result = await HttpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            if (result?.Succeeded != true)
+            {
+                throw new Exception("External authentication error");
+            }
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                var externalClaims = result.Principal.Claims.Select(c => $"{c.Type}: {c.Value}");
+                _logger.LogDebug("External claims: {@claims}", externalClaims);
+            }
+
+            // retrieve return URL
+            var returnUrl = result.Properties.Items["returnUrl"] ?? "~/";
+
+            return Redirect(returnUrl);
+        }
+
+        private async Task<IActionResult> ProcessNegociateLoginAsync(string returnUrl)
+        {
+            // see if windows auth has already been requested and succeeded
+            var result = await HttpContext.AuthenticateAsync(NegotiateDefaults.AuthenticationScheme);
+
+            if (result?.Principal is WindowsPrincipal wp)
+            {
+                // we will issue the external cookie and then redirect the
+                // user back to the external callback, in essence, treating windows
+                // auth the same as any other external authentication mechanism
+                var props = new AuthenticationProperties()
+                {
+                    RedirectUri = Url.Action("Callback"),
+                    Items =
+                    {
+                        { "returnUrl", returnUrl },
+                        { "scheme", NegotiateDefaults.AuthenticationScheme },
+                    },
+                };
+
+                var id = new ClaimsIdentity(NegotiateDefaults.AuthenticationScheme);
+                id.AddClaim(new Claim(JwtClaimTypes.Subject, wp.FindFirst(ClaimTypes.PrimarySid).Value));
+                id.AddClaim(new Claim(JwtClaimTypes.Name, wp.Identity.Name));
+                id.AddClaim(new Claim(ClaimTypes.Name, wp.Identity.Name));
+
+                await HttpContext.SignInAsync(
+                    CookieAuthenticationDefaults.AuthenticationScheme,
+                    new ClaimsPrincipal(id),
+                    props);
+                return Redirect(props.RedirectUri);
+            }
+            else
+            {
+                // trigger windows auth
+                // since windows auth don't support the redirect uri,
+                // this URL is re-triggered when we call challenge
+                return Challenge(NegotiateDefaults.AuthenticationScheme);
+            }
+        }
+    }
+}

--- a/src/WebApp/Area/Identity/NameUserIdProvider.cs
+++ b/src/WebApp/Area/Identity/NameUserIdProvider.cs
@@ -1,0 +1,25 @@
+﻿using IdentityModel;
+using Microsoft.AspNetCore.SignalR;
+using System.Linq;
+
+namespace OfficeEntry.WebApp.Area.Identity
+{
+    /// <remarks>
+    /// If Windows authentication is configured in your app, SignalR can use
+    /// that identity to secure hubs. However, to send messages to individual
+    /// users, you need to add a custom User ID provider. The Windows
+    /// authentication system doesn't provide the "Name Identifier" claim.
+    /// SignalR uses the claim to determine the user name.
+    ///
+    /// https://docs.microsoft.com/en-us/aspnet/core/signalr/authn-and-authz?view=aspnetcore-3.1
+    /// </remarks>
+    public class NameUserIdProvider : IUserIdProvider
+    {
+        public string GetUserId(HubConnectionContext connection)
+        {
+            var nameClaim = connection.User.Claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Name);
+
+            return nameClaim?.Value;
+        }
+    }
+}

--- a/src/WebApp/Area/Identity/Services/CurrentUserService.cs
+++ b/src/WebApp/Area/Identity/Services/CurrentUserService.cs
@@ -3,7 +3,7 @@ using OfficeEntry.Application.Common.Interfaces;
 using System;
 using System.Security.Claims;
 
-namespace OfficeEntry.WebApp.Services
+namespace OfficeEntry.WebApp.Area.Identity.Services
 {
     public class CurrentUserService : ICurrentUserService
     {

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -1,16 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Exceptions;
 using Serilog.Exceptions.Core;
+using System;
 
 namespace OfficeEntry.WebApp
 {
@@ -28,8 +22,8 @@ namespace OfficeEntry.WebApp
                 .ReadFrom
                 .Configuration(configuration)
                 .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder()
-                    .WithDefaultDestructurers())                
-                .Filter.ByExcluding("RequestPAth = '/health' and StatusCode = 200")
+                    .WithDefaultDestructurers())
+                .Filter.ByExcluding("RequestPath = '/health' and StatusCode = 200")
                 .CreateLogger();
 
             try

--- a/src/WebApp/Properties/launchSettings.json
+++ b/src/WebApp/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "iisSettings": {
     "windowsAuthentication": true,
-    "anonymousAuthentication": false,
+    "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:63440",
       "sslPort": 44381

--- a/src/WebApp/Shared/MainLayout.razor
+++ b/src/WebApp/Shared/MainLayout.razor
@@ -1,15 +1,23 @@
 ﻿@inherits LayoutComponentBase
 
-<div class="sidebar">
-    <NavMenu />
-</div>
+<AuthorizeView>
+    <Authorized>
+        <div class="sidebar">
+            <NavMenu />
+        </div>
 
-<div class="main">
-    <div class="top-row px-4">
-        <LoginDisplay />        
-    </div>
+        <div class="main">
+            <div class="top-row px-4">
+                <LoginDisplay />
+            </div>
 
-    <div class="content px-4">
-        @Body
-    </div>
-</div>
+            <div class="content px-4">
+                @Body
+            </div>
+        </div>
+    </Authorized>
+    <NotAuthorized>
+        <Loading />
+        <RedirectToLogin />
+    </NotAuthorized>
+</AuthorizeView>

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="3.1.5" /> 
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="3.1.5" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.76" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
@@ -26,5 +26,5 @@
     <ProjectReference Include="..\Domain\Domain.csproj" />
     <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/WebApp/_Imports.razor
+++ b/src/WebApp/_Imports.razor
@@ -9,3 +9,4 @@
 @using Microsoft.JSInterop
 @using OfficeEntry.WebApp
 @using OfficeEntry.WebApp.Shared
+@using OfficeEntry.WebApp.Area.Identity.Components


### PR DESCRIPTION
Windows authentication mechanism is only available to IE and Edge.

Since Safari/Chrome/Firefox don't support authentication over websockets we are now using Cookie Authentication in combination with Windows (Negociate) Authentication.

The user is authenticated over the Negociate Microsoft Windows authentication mechanism, a cookie is created and this cookie is then passed with the websocket to validate the identity of the user.