### PR TITLE
Invoking void to discard uneeded datepicker result, removing the Json…

### DIFF
--- a/src/WebApp/Shared/Survey.razor.cs
+++ b/src/WebApp/Shared/Survey.razor.cs
@@ -77,8 +77,8 @@ public partial class Survey
 
         await _module.InvokeVoidAsync("register", _objectReference, locale);
         await _module.InvokeVoidAsync("init", Id, Class, SurveyUrl, dataValue);
-        await JSRuntime.InvokeAsync<object>("initializeDatepicker", locale);
-        await JSRuntime.InvokeAsync<object>("initializeSelect2", locale);
+        await JSRuntime.InvokeVoidAsync("initializeDatepicker", locale);
+        await JSRuntime.InvokeVoidAsync("initializeSelect2", locale);
     }
 
     public async Task<string> GetData()

--- a/tests/WebApp.UnitTests/SurveyComponentTests.cs
+++ b/tests/WebApp.UnitTests/SurveyComponentTests.cs
@@ -36,8 +36,8 @@ public class SurveyComponentTests : TestContext
             .SetupVoid(invocation => invocation.Identifier == "init")
             .SetVoidResult();
 
-        var plannedInitializeDatepicker = JSInterop.Setup<object>("initializeDatepicker", "en");
-        var plannedinitializeSelect2 = JSInterop.Setup<object>("initializeSelect2");
+        var plannedInitializeDatepicker = JSInterop.SetupVoid("initializeDatepicker", "en");
+        var plannedinitializeSelect2 = JSInterop.SetupVoid("initializeSelect2");
     }
 
     [Fact]


### PR DESCRIPTION
… serialization causing the error.

This should remove an error happening every load of the Booking Page, considerably reducing the error logs.

Microsoft.JSInterop.JSException: Converting circular structure to JSON is the error.

For information on it: https://stackoverflow.com/questions/73358967/error-microsoft-jsinterop-jsexception-converting-circular-structure-to-json-in